### PR TITLE
Fix condition to accept 0 value for pluralBy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@etvas/i18n",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etvas/i18n",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Etvas i18n components",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/I18nService.js
+++ b/src/I18nService.js
@@ -36,7 +36,7 @@ export class I18nService extends EventEmitter {
   translate(key, language, args, pluralBy) {
     this.ensureSupportedLanguage(language)
 
-    if (pluralBy) {
+    if (pluralBy !== undefined) {
       return this.translateMarkedLabel(key, language, args, pluralBy)
     }
 


### PR DESCRIPTION
https://etvas.atlassian.net/browse/ETV-10114

## Issue
Currently when someone is trying to translate a label with the `translate` function and is specifying the `pluralBy` argument as 0, which is a valid array index for `args` the if condition on line 39 is going to be false and not translate the marked label, when it should do so.

## Fix
Refactor the if condition on line 39 to allow for 0 value for the `pluralBy` argument